### PR TITLE
Remove -e flag from get-login output

### DIFF
--- a/aws/ecr/ecr.go
+++ b/aws/ecr/ecr.go
@@ -64,7 +64,7 @@ func (c *Client) GetLogin() (string, error) {
 		return "", errors.Errorf("authorization data must be user:pass. got: %q", string(data))
 	}
 
-	return fmt.Sprintf("docker login -u %s -p %s -e none %s", ss[0], ss[1], *authData.ProxyEndpoint), nil
+	return fmt.Sprintf("docker login -u %s -p %s %s", ss[0], ss[1], *authData.ProxyEndpoint), nil
 }
 
 // ListImages returns the list of stored Docker images

--- a/aws/ecr/ecr_test.go
+++ b/aws/ecr/ecr_test.go
@@ -28,7 +28,7 @@ func TestGetLogin(t *testing.T) {
 		api: api,
 	}
 
-	expected := "docker login -u username -p password -e none https://012345678910.dkr.ecr.us-east-1.amazonaws.com"
+	expected := "docker login -u username -p password https://012345678910.dkr.ecr.us-east-1.amazonaws.com"
 
 	got, err := client.GetLogin()
 	if err != nil {


### PR DESCRIPTION
`docker login -e` option has been completely deprecated from Docker 17.06.0-ce.
https://docs.docker.com/release-notes/docker-ce/#17060-ce-2017-06-28